### PR TITLE
Remove squash and rebase merge checks

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -839,28 +839,6 @@ def _enable_merge_commit(repo: Repository) -> RESULT:
 
 
 @define_rule(
-    name="disable-squash-merge",
-    log_message="Repository should not allow squash merging",
-    level="warning",
-)
-def _disable_squash_merge(repo: Repository) -> RESULT:
-    if not repo.allow_squash_merge:
-        return OK
-    return FAIL
-
-
-@define_rule(
-    name="disable-rebase-merge",
-    log_message="Repository should not allow rebase merging",
-    level="warning",
-)
-def _disable_rebase_merge(repo: Repository) -> RESULT:
-    if not repo.allow_rebase_merge:
-        return OK
-    return FAIL
-
-
-@define_rule(
     name="dependabot-schedule-weekly",
     log_message="Dependabot should be scheduled weekly",
     level="warning",


### PR DESCRIPTION
## Summary
- stop emitting warnings about disallowing squash merges or rebase merges

## Testing
- `ruff format --diff .`
- `ruff check .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_6862099c70ec8326bf6c38b6a0aaf195