### PR TITLE
Add prefer-uv-lock rule

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -724,9 +724,29 @@ def _requirements_txt_uv_compiled(repo: Repository) -> RESULT:
     return FAIL
 
 
+@define_rule(
+    name="prefer-uv-lock",
+    log_message="Prefer uv.lock instead of requirements.txt",
+    level="warning",
+)
+def _prefer_uv_lock(repo: Repository) -> RESULT:
+    if not _has_requirements_txt(repo):
+        return SKIP
+    if _has_uv_lock(repo):
+        return OK
+    return FAIL
+
+
 @cache
 def _has_requirements_txt(repo: Repository) -> bool:
     if _get_contents(repo, path="requirements.txt"):
+        return True
+    return False
+
+
+@cache
+def _has_uv_lock(repo: Repository) -> bool:
+    if _get_contents(repo, path="uv.lock"):
         return True
     return False
 


### PR DESCRIPTION
## Summary
- warn when a repository uses `requirements.txt` instead of `uv.lock`

## Testing
- `ruff format --diff gh_audit.py`
- `ruff check gh_audit.py`
- `mypy gh_audit.py`


------
https://chatgpt.com/codex/tasks/task_e_686235db0d8c8326aa2616f1b3f179a5