### PR TITLE
Add rule for legacy version classifiers

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -553,6 +553,22 @@ def _missing_pyproject_requires_python(repo: Repository) -> RESULT:
     return FAIL
 
 
+@define_rule(
+    name="pyproject-legacy-version-classifiers",
+    log_message="Use requires-python instead of version classifiers",
+    level="warning",
+)
+def _pyproject_legacy_version_classifiers(repo: Repository) -> RESULT:
+    pyproject = _load_pyproject(repo)
+    if not pyproject:
+        return SKIP
+
+    for classifier in _pyproject_classifiers(repo):
+        if classifier.startswith("Programming Language :: Python ::"):
+            return FAIL
+    return OK
+
+
 @cache
 def _pyproject_all_dependencies(repo: Repository) -> set[str]:
     deps: set[str] = set()


### PR DESCRIPTION
## Summary
- flag legacy Python classifiers in `pyproject.toml`
- simplify detection by looking for any Python version classifier

## Testing
- `uv run ruff format --diff .`
- `uv run ruff check .`
- `uv run mypy .`


------
https://chatgpt.com/codex/tasks/task_e_6876781771ac832697815df787aa2db6