### PR TITLE
Add pyproject-fmt indent rule

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -636,6 +636,29 @@ def _pyproject_depends_on_requests(repo: Repository) -> RESULT:
 
 
 @cache
+def _pyproject_fmt_indent(repo: Repository) -> int | None:
+    return cast(
+        int | None,
+        _load_pyproject(repo).get("tool", {}).get("pyproject-fmt", {}).get("indent"),
+    )
+
+
+@define_rule(
+    name="missing-pyproject-fmt-indent",
+    log_message="tool.pyproject-fmt.indent should be 4",
+    level="warning",
+)
+def _missing_pyproject_fmt_indent(repo: Repository) -> RESULT:
+    pyproject = _load_pyproject(repo)
+    if not pyproject:
+        return SKIP
+
+    if _pyproject_fmt_indent(repo) == 4:
+        return OK
+    return FAIL
+
+
+@cache
 def _ruff_extend_select(repo: Repository) -> list[str]:
     return cast(
         list[str],


### PR DESCRIPTION
## Summary
- ensure repositories with `pyproject.toml` specify an indent of 4 for `tool.pyproject-fmt`

## Testing
- `uv run ruff format --diff .`
- `uv run ruff check .`
- `uv run mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68768a4c692c8326bc6a5e9f999eb6e9