### PR TITLE
Fix pyproject classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,6 @@ license = "MIT"
 license-files = [ "LICENSE" ]
 authors = [ { name = "Joshua Peek" } ]
 requires-python = ">=3.11"
-classifiers = [
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-]
 
 dependencies = [
     "click>=8.1.1",


### PR DESCRIPTION
## Summary
- remove `License ::` classifier from `pyproject.toml`
- drop Python version classifiers; rely on `requires-python`

## Testing
- `uv run ruff format --diff .`
- `uv run ruff check .`
- `uv run mypy .`

------
https://chatgpt.com/codex/tasks/task_e_68768c85662083268cc563b952f9ae83