### PR TITLE
Remove weekly Dependabot rule

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -892,19 +892,6 @@ def _enable_merge_commit(repo: Repository) -> RESULT:
 
 
 @define_rule(
-    name="dependabot-schedule-weekly",
-    log_message="Dependabot should be scheduled weekly",
-    level="warning",
-)
-def _dependabot_schedule_weekly(repo: Repository) -> RESULT:
-    if not _dependabot_config(repo):
-        return SKIP
-    if _dependabot_update_schedule_intervals(repo) != {"weekly"}:
-        return FAIL
-    return OK
-
-
-@define_rule(
     name="pip-dependabot",
     log_message="Dependabot should be enabled for pip ecosystem",
     level="error",


### PR DESCRIPTION
## Summary
- drop the `dependabot-schedule-weekly` rule
- restore `renovate-nix` rule per review feedback
- keep whitespace around release check

## Testing
- `uv run ruff format --diff .`
- `uv run ruff check .`
- `uv run mypy .`


------
https://chatgpt.com/codex/tasks/task_e_6879996bbaf08326a3686ba81cf6db93