### PR TITLE
Handle empty repository case

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -378,7 +378,13 @@ def _get_contents_text(repo: Repository, path: str) -> str:
 
 @cache
 def _ls_tree(repo: Repository) -> list[Path]:
-    return [Path(item.path) for item in repo.get_git_tree("HEAD", recursive=True).tree]
+    try:
+        tree = repo.get_git_tree("HEAD", recursive=True)
+    except GithubException as exc:
+        if exc.status == 404:
+            return []
+        raise
+    return [Path(item.path) for item in tree.tree]
 
 
 @cache


### PR DESCRIPTION
## Summary
- avoid crashing when a repo is empty by catching the 404 error in `_ls_tree`

## Testing
- `uv run ruff format --diff .`
- `uv run ruff check .`
- `uv run mypy .`


------
https://chatgpt.com/codex/tasks/task_e_688165dbec7083269c6bae33cc417f6a