### PR TITLE
Handle empty repositories in tree walk

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -381,7 +381,7 @@ def _ls_tree(repo: Repository) -> list[Path]:
     try:
         tree = repo.get_git_tree("HEAD", recursive=True)
     except GithubException as exc:
-        if exc.status == 404:
+        if exc.status in {404, 409}:
             return []
         raise
     return [Path(item.path) for item in tree.tree]


### PR DESCRIPTION
## Summary
- Avoid crashing on empty repositories by treating GitHub's 409 error as an empty tree

## Testing
- `uv run ruff format --diff .`
- `uv run ruff check .`
- `uv run mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a502eb2c388326a90d7f718b0b49c3