### PR TITLE
Fix tag-stable-projects release commit detection

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -1782,12 +1782,16 @@ def _repository_has_changes_since_released(repo: Repository) -> bool:
     except GithubException:
         return True
 
-    for commit in repo.get_commits(since=release.created_at, author=repo.owner):
-        if len(commit.parents) > 1:
-            continue
+    default_branch = repo.default_branch
+    if default_branch is None:
         return True
 
-    return False
+    try:
+        comparison = repo.compare(base=release.tag_name, head=default_branch)
+    except GithubException:
+        return True
+
+    return comparison.ahead_by > 0
 
 
 @cache


### PR DESCRIPTION
## Summary
- ensure `tag-stable-projects` compares the default branch to the latest release tag before warning

## Testing
- uv run ruff format --diff .
- uv run ruff check .
- uv run mypy .

------
https://chatgpt.com/codex/tasks/task_e_68cc23bc919083268470eae71b9abe58