### PR TITLE
Use ubuntu-slim runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   ruff:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
 
     env:
       RUFF_OUTPUT_FORMAT: github
@@ -24,7 +24,7 @@ jobs:
         run: uv run ruff check .
 
   mypy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   merge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     if: github.actor == 'dependabot[bot]' && github.repository == 'josh/gh-audit'
 
     steps:


### PR DESCRIPTION
## Summary
- update lint workflow jobs to use ubuntu-slim container runners
- migrate the Dependabot merge workflow to ubuntu-slim runners

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692365c58bf88326b88783fe1f6efb52)