### PR TITLE
Restore original dependabot schedule rule message

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -874,7 +874,7 @@ def _dependabot_schedule(repo: Repository) -> RESULT:
         if interval == "monthly":
             continue
 
-        if interval == "weekly" and cooldown_days == 7:
+        if interval == "weekly" and cooldown_days is not None and cooldown_days >= 7:
             continue
 
         return FAIL


### PR DESCRIPTION
## Summary
- revert the dependabot-schedule log message to its original wording while keeping the expanded cooldown logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ae6df274832693f544a4f1a0055f)