### PR TITLE
Fix pyproject-author-name rule level crashing on failure

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -444,7 +444,7 @@ def _pyproject_author_emails(repo: Repository) -> set[str]:
 @define_rule(
     name="pyproject-author-name",
     log_message="project.authors[0].name missing in pyproject.toml",
-    level="warn",
+    level="warning",
 )
 def _pyproject_author_name(repo: Repository) -> RESULT:
     pyproject = _load_pyproject(repo)


### PR DESCRIPTION
The rule was defined with level="warn", but Rule.__call__ only binds the level label for "warning" or "error". Any repository failing this rule raised UnboundLocalError and aborted the audit run.