### PR TITLE
Guard workflow parsing against non-mapping YAML documents

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -1276,6 +1276,8 @@ def _get_workflow_by_path(repo: Repository, path: Path) -> Workflow:
         return empty_workflow
     try:
         workflow = yaml.safe_load(contents.decoded_content.decode("utf-8"))
+        if not isinstance(workflow, dict):
+            return empty_workflow
         # Workaround stupid YAML parsing bug
         if True in workflow:
             workflow["on"] = workflow.pop(True)


### PR DESCRIPTION
An empty, comments-only, or scalar .github/workflows/*.yml file makes yaml.safe_load return None or a non-dict value, so the following 'True in workflow' check raised TypeError and aborted the audit run. Fall back to the empty workflow unless the document is a mapping.