### PR TITLE
Skip non-YAML entries under .github/workflows instead of asserting

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -1293,7 +1293,8 @@ def _get_workflow_paths(repo: Repository) -> list[Path]:
             and path.parts[0] == ".github"
             and path.parts[1] == "workflows"
         ):
-            assert path.suffix == ".yml" or path.suffix == ".yaml"
+            if path.suffix not in (".yml", ".yaml"):
+                continue
             paths.append(path)
     return paths
 


### PR DESCRIPTION
The recursive git tree includes subdirectories (whose paths have no suffix) and any stray non-YAML files like a README.md, which tripped the suffix assertion and aborted the audit run.