### PR TITLE
Guard dependabot config parsing against non-mapping YAML

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -852,12 +852,12 @@ def _dependabot_config(repo: Repository) -> dict[str, Any]:
     if not contents:
         return {}
     try:
-        return cast(
-            dict[str, Any],
-            yaml.safe_load(contents.decoded_content.decode("utf-8")),
-        )
+        config = yaml.safe_load(contents.decoded_content.decode("utf-8"))
     except yaml.YAMLError:
         return {}
+    if not isinstance(config, dict):
+        return {}
+    return cast(dict[str, Any], config)
 
 
 def _dependabot_update_schedule_intervals(repo: Repository) -> set[str]:


### PR DESCRIPTION
yaml.safe_load returns None for an empty or comments-only .github/dependabot.yml, so callers doing .get() on the result raised AttributeError and aborted the audit run.