### PR TITLE
Handle empty repositories in tag-new-release recent-changes check

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -1917,10 +1917,14 @@ def _tag_stable_projects(repo: Repository) -> RESULT:
 @cache
 def _repository_has_recent_changes(repo: Repository) -> bool:
     since = datetime.now(tz=UTC) - timedelta(days=90)
-    for commit in repo.get_commits(since=since, author=repo.owner):
-        if len(commit.parents) > 1:
-            continue
-        return True
+    try:
+        for commit in repo.get_commits(since=since, author=repo.owner):
+            if len(commit.parents) > 1:
+                continue
+            return True
+    except GithubException as exc:
+        if exc.status != 409:
+            raise
     return False
 
 


### PR DESCRIPTION
repo.get_commits raises GithubException(409 Git Repository is empty) on a repository with no commits, aborting the audit run. Treat it like the existing 404/409 handling in _ls_tree and report no recent changes.