### PR TITLE
Fix missing-ruff and missing-mypy rules that could never fail

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -1459,7 +1459,7 @@ def _missing_ruff_error(repo: Repository) -> RESULT:
         if re.search("ruff ", step.get("run", "")):
             return OK
 
-    return OK
+    return FAIL
 
 
 @define_rule(
@@ -1475,7 +1475,7 @@ def _missing_ruff_warning(repo: Repository) -> RESULT:
         if re.search("ruff ", step.get("run", "")):
             return OK
 
-    return OK
+    return FAIL
 
 
 class RepositoryRulesetRequiredStatusCheck(TypedDict):
@@ -1568,7 +1568,7 @@ def _missing_mypy(repo: Repository) -> RESULT:
         if re.search("mypy ", step.get("run", "")):
             return OK
 
-    return OK
+    return FAIL
 
 
 @define_rule(


### PR DESCRIPTION
The step-iteration rewrite in 18b2379 left these three rules returning OK on their fall-through path, so a Python repository with no ruff or mypy workflow step was never reported. Restore the FAIL result the pre-refactor _job_runs logic produced.