### PR TITLE
Ignore blank and option lines when checking requirements.txt pins

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -810,11 +810,12 @@ def _requirements_txt(repo: Repository) -> str:
 def _requirements_txt_is_exact(repo: Repository) -> bool:
     if text := _requirements_txt(repo):
         for line in text.splitlines():
-            if line.lstrip().startswith("#"):
+            stripped = line.strip()
+            if not stripped or stripped.startswith(("#", "-")):
                 continue
-            if "@" in line:
+            if "@" in stripped:
                 continue
-            if "==" not in line:
+            if "==" not in stripped:
                 return False
         return True
     else:


### PR DESCRIPTION
A blank separator line or a pip option line like -r or --index-url has no == specifier, so requirements-txt-exact reported a false failure on fully pinned files.