### PR TITLE
Evaluate branch rulesets against the repository default branch

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -1495,11 +1495,9 @@ RepositoryRuleset = RepositoryRulesetRequiredStatusChecks
 
 
 @cache
-def _get_repo_rulesets(
-    repo: Repository, branch: str = "main"
-) -> list[RepositoryRuleset]:
+def _get_repo_rulesets(repo: Repository) -> list[RepositoryRuleset]:
     _, data = repo._requester.requestJsonAndCheck(
-        "GET", f"{repo.url}/rules/branches/{branch}"
+        "GET", f"{repo.url}/rules/branches/{repo.default_branch}"
     )
     return cast(list[RepositoryRuleset], data)
 


### PR DESCRIPTION
_get_repo_rulesets hardcoded 'main', so on repositories with a different default branch the required-*-status-check rules evaluated rules for a nonexistent branch and reported false failures.