### PR TITLE
Exclude unpinnable action refs from unpinned-workflow-actions

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -1396,6 +1396,9 @@ def _unpinned_workflow_branch_actions(repo: Repository) -> RESULT:
         if not uses:
             continue
 
+        if uses.startswith(("./", "docker://")):
+            continue
+
         if not re.fullmatch(pattern, uses):
             return FAIL
 


### PR DESCRIPTION
Local composite actions (uses: ./...) ride the repository's own commit and cannot carry an @sha suffix, and docker:// image references pinned by sha256 digest are already immutable. Both could never match the 40-hex commit pattern and were reported as unpinned.