### PR TITLE
Resolve gh auth token default lazily

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -55,7 +55,7 @@ _RULE_TYPE = RuleParamType()
     help="GitHub API token",
     metavar="TOKEN",
     required=True,
-    default=_gh_auth_token(),
+    default=_gh_auth_token,
 )
 @click.option("--verbose", is_flag=True, default=False, help="Enable debug logging")
 @click.option(


### PR DESCRIPTION
Passing the function instead of its result stops every invocation from spawning a gh subprocess at import time, including --help, --version, and runs where GITHUB_TOKEN is already set; click only calls callable defaults when the value is actually needed.