### PR TITLE
Fix repository argument handling in main

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -96,8 +96,14 @@ def main(
     with Github(auth=Auth.Token(github_token)) as g:
         user = g.get_user()
 
+        audited: set[str] = set()
+
         for name in repository:
-            repo = user.get_repo(name)
+            if "/" in name:
+                repo = g.get_repo(name)
+            else:
+                repo = user.get_repo(name)
+            audited.add(repo.full_name)
             for rule in rules:
                 rule(repo=repo)
 
@@ -106,6 +112,8 @@ def main(
                 if repo.owner.login != user.login:
                     continue
                 if repo.archived or repo.fork:
+                    continue
+                if repo.full_name in audited:
                     continue
                 for rule in rules:
                     rule(repo=repo)


### PR DESCRIPTION
Arguments in owner/name form crashed deep inside the first rule: AuthenticatedUser.get_repo URL-quotes the whole string into /repos/<user>/owner%2Fname and the lazy Repository 404s on first attribute access. Resolve names containing a slash with Github.get_repo instead. Also skip repositories already audited from explicit arguments when --active walks the account, which previously reported them twice.