### PR TITLE
Ignore environment markers when checking dependency lower bounds

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -597,7 +597,13 @@ def _pyproject_all_dependencies(repo: Repository) -> set[str]:
 
 
 def _pydep_has_lower_bound(dep: str) -> bool:
-    return "==" in dep or ">" in dep or "~=" in dep or "@" in dep
+    requirement = dep.split(";")[0]
+    return (
+        "==" in requirement
+        or ">" in requirement
+        or "~=" in requirement
+        or "@" in requirement
+    )
 
 
 @define_rule(


### PR DESCRIPTION
An operator inside an environment marker, like
'foo; python_version >= "3.9"', satisfied the lower-bound check even though the dependency itself is unbounded. Only inspect the requirement before the marker separator.