### PR TITLE
Run all rules sharing a name when selected with --rule

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -84,7 +84,8 @@ def main(
 
     rules: list[Rule] = RULES
     if override_rules:
-        rules = list(override_rules)
+        names = {rule.name for rule in override_rules}
+        rules = [rule for rule in RULES if rule.name in names]
     logger.debug("Applying %d rules", len(rules))
 
     global rule_message_format


### PR DESCRIPTION
git-size and missing-ruff each define an error and a warning variant under the same name, but --rule resolved to the first match only, so the warning variants were impossible to select. Expand the selection by name instead.