### PR TITLE
Check every uv ecosystem entry in uv-dependabot-lockfile-only

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -1019,12 +1019,13 @@ def _dependabot_ignores_ruff_patches(repo: Repository) -> RESULT:
     level="error",
 )
 def _uv_dependabot_lockfile_only(repo: Repository) -> RESULT:
+    found = False
     for update in _dependabot_config(repo).get("updates", []):
         if update.get("package-ecosystem") == "uv":
-            if update.get("versioning-strategy") == "lockfile-only":
-                return OK
-            return FAIL
-    return SKIP
+            if update.get("versioning-strategy") != "lockfile-only":
+                return FAIL
+            found = True
+    return OK if found else SKIP
 
 
 @define_rule(


### PR DESCRIPTION
The rule returned from the first package-ecosystem: uv entry, so a second entry without versioning-strategy: lockfile-only was never examined.