### PR TITLE
Allow weekly nix ecosystem updates without a cooldown

### DIFF
--- a/gh_audit.py
+++ b/gh_audit.py
@@ -907,6 +907,9 @@ def _dependabot_schedule(repo: Repository) -> RESULT:
         if interval == "monthly":
             continue
 
+        if interval == "weekly" and update.get("package-ecosystem") == "nix":
+            continue
+
         if interval == "weekly" and cooldown_days is not None and cooldown_days >= 7:
             continue
 


### PR DESCRIPTION
The Dependabot nix flake updater runs weekly without a cooldown by convention, so dependabot-schedule should not demand one for package-ecosystem: nix entries. Other ecosystems still require monthly or weekly with a 7-day cooldown.